### PR TITLE
update for v3 pdf.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # pdf-table-extractor
+
 Extractor tables from PDF
 
 Web DEMO: https://ronnywang.github.io/pdf-table-extractor/
 
-Command line tools install
---------------------------
-1. git clone https://github.com/mozilla/pdf.js.git  
-2. cd pdf.js  
-3. npm install -g gulp-cli  
-4. npm install  
-5. gulp generic  
-5. cd ../  
-6. node parse-cmd.js samples/pta_10229_131308_94274.pdf  
+## Command line tools install
 
-License
--------
+1. git clone https://github.com/mozilla/pdf.js.git
+1. cd pdf.js
+1. git checkout v3.11.174
+1. npm install -g gulp-cli
+1. npm install
+1. gulp generic
+1. cd ../
+1. node parse-cmd.js samples/pta_10229_131308_94274.pdf
+
+## License
+
 BSD License

--- a/parse-cmd.js
+++ b/parse-cmd.js
@@ -8,7 +8,7 @@ require('./pdf.js/examples/node/domstubs.js');
 require('./pdf-table-extractor.js');
 
 // Run `gulp dist` to generate 'pdfjs-dist' npm package files.
-PDFJS = require('./pdf.js/build/dist');
+PDFJS = require('./pdf.js/build/generic/build/pdf.js');
 PDFJS.cMapUrl = './pdf.js/build/generic/web/cmaps/';
 PDFJS.cMapPacked = true;
 
@@ -19,9 +19,10 @@ var data = new Uint8Array(fs.readFileSync(pdfPath));
 
 // Will be using promises to load document, pages and misc data instead of
 // callback.
-PDFJS.getDocument(data).then(pdf_table_extractor).then(function (result) {
+PDFJS.getDocument(data).promise.then(pdf_table_extractor).then(function (result) {
     console.log(JSON.stringify(result));
+    // fs.writeFileSync('output.json', JSON.stringify(result));
 }, function (err) {
-    console.error('Error: ' + err);
+    console.error('Error: ' + err, err.stack);
 });
 

--- a/pdf-table-extractor.js
+++ b/pdf-table-extractor.js
@@ -1,3 +1,5 @@
+const pdfjsLib = require('./pdf.js/build/generic/build/pdf.js');
+
 // modify from https://github.com/mozilla/pdf.js/blob/master/examples/node/pdf2svg.js
 pdf_table_extractor_progress = function(result){
 };


### PR DESCRIPTION
I needed a fix for RTL language support in pdf.js and found some issues pulling in a more recent version:

* v4 made some big refactors around ESM modules and typescript that led the team to remove a module we're depending on (domstubs.js)
* v3 had better support for the existing project structure with some minor tweaks:
  * new gulp dist path
  * promise not returned by getDocument call, now a "task" class wrapper with promise getter

I've updated the readme to make it clear what version of PDF.js is supported with these changes, since it seems that V4 will require a fairly significant overhaul

RE: the global `require` "hacks", I'm not sure how it worked before, but the existing require calls in parse-cmd were not making `pdfjsLib` available so i added an explicit require call to `pdf-table-extractor.js`. This tells me that the require for domstubs might not be necessary but I didn't check that since the code as-is works for my needs.